### PR TITLE
Use inputs instead of pkgs to get break-enforcer bin

### DIFF
--- a/nix_module.nix
+++ b/nix_module.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 
@@ -105,7 +106,7 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = ''
-          ${pkgs.break-enforcer}/bin/break-enforcer run \
+          ${inputs.break-enforcer.defaultPackage.x86_64-linux}/bin/break-enforcer run \
           --work-duration ${cfg.work-duration} \
           --break-duration ${cfg.break-duration} \
            ${


### PR DESCRIPTION
This should allow user to not use the overlay for pkgs. @yara-blue could you test if this still works for your setup?